### PR TITLE
Rename c-lightning to Core Lightning on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
             
               <h2>Features</h2>
               <p>
-                LNbits can run on top of any lightning-network funding source, currently there is support for LND, c-lightning, Spark, LNpay, OpenNode, lntxbot, with more being added regularly.
+                LNbits can run on top of any lightning-network funding source, currently there is support for LND, Core Lightning, Spark, LNpay, OpenNode, lntxbot, with more being added regularly.
               </p>
             </div>
           </div>


### PR DESCRIPTION
Small update on the LNBits page (context: https://blog.blockstream.com/en-c-lightning-is-now-core-lightning/)