### PR TITLE
feat: add `hardware-wallet` as `submodule`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "hardware-wallet"]
+	path = hardware-wallet
+	url = https://github.com/lnbits/hardware-wallet


### PR DESCRIPTION
- add (only) a pointer to the `hardware-wallet` repo
- binaries are maintained on the `hardware-wallet` repo
- the installer allows flashing the `hardware-wallet` binaries directly from the Browser

The change will result in a valid page for this URL: https://lnbits.github.io/hardware-wallet
**Note**: It will automatically redirect to: https://lnbits.github.io/hardware-wallet/installer/



Currently live at: https://motorina0.github.io/hardware-wallet/

![image](https://user-images.githubusercontent.com/2951406/189902050-6d58720f-821f-49e1-adbc-38a5849f72ec.png)

